### PR TITLE
Fix indexing wildcard exports from directories with index files

### DIFF
--- a/src/Tsunami.ts
+++ b/src/Tsunami.ts
@@ -93,7 +93,6 @@ export class Tsunami {
             const promises: Promise<void>[] = [];
 
             Object.keys(deps).forEach(dep => {
-                /* indexExternalModule(dep); */
                 try {
                     fs.accessSync(deps[dep]);
                     let typings = deps[dep];


### PR DESCRIPTION
Example:

`export * from "bar/foo";` where "bar/foo/index.d.ts" exists.